### PR TITLE
Fix process substitution on BSD

### DIFF
--- a/Next.pm
+++ b/Next.pm
@@ -265,7 +265,7 @@ sub files {
     return sub {
         while (@queue) {
             my ($dirname,$file,$fullpath) = splice( @queue, 0, 3 ); ## no critic (ProhibitMagicNumbers)
-            if ( -f $fullpath || -p $fullpath ) {
+            if ( -f $fullpath || -p $fullpath || $fullpath =~ m{^/dev/fd} ) {
                 if ( $filter ) {
                     local $_ = $file;
                     local $File::Next::dir = $dirname;


### PR DESCRIPTION
On Linux systems, process substitution (in Bash) is implemented using named pipes.
BSD systems, on the other hand, seems to be implemented using special
files under /dev/fd.  According to the bash manual:

```
Process substitution is supported on systems that support named pipes (FIFOs)
or the /dev/fd method of naming open files.  It takes the form of <(list) or
>(list).  The process list is run with its input or output connected to a
FIFO or some  file  in /dev/fd.  The name of this file is passed as an
argument to the current command as the result of the expansion.  If the
>(list) form is used, writing to the file will provide input for list.  If
the <(list) form is used, the file passed as an argument should be read to
obtain the output of list.
```

This change checks for the latter case so File::Next works properly on
*BSD.
