### PR TITLE
Fall back to error handler for warning if no warn handler is found

### DIFF
--- a/Next.pm
+++ b/Next.pm
@@ -333,7 +333,7 @@ sub from_file {
 
     my ($parms,@queue) = _setup( \%files_defaults, @_ );
     my $err  = $parms->{error_handler};
-    my $warn = $parms->{warn_handler};
+    my $warn = $parms->{warning_handler};
 
     my $filename = $queue[1];
 

--- a/t/from_file.t
+++ b/t/from_file.t
@@ -2,10 +2,13 @@
 
 use strict;
 use warnings;
-use Test::More tests => 10;
+use Test::More tests => 13;
 
 use lib 't';
 use Util;
+
+use File::Copy ();
+use File::Temp;
 
 use File::Next;
 
@@ -67,4 +70,22 @@ FROM_MISSING_FILE: {
     like( $@, qr/\QUnable to open flargle-bargle.txt/, 'Proper error message' );
     ok( !defined($iter), 'Iterator should be null' );
     ok( !defined($rc), 'Eval should fail' );
+}
+
+FROM_OK_FILE_BUT_MISSING: {
+    my $warn_called;
+    local $SIG{__WARN__} = sub { $warn_called = 1 };
+
+    my $tempfile = File::Temp->new;
+    File::Copy::copy('t/filelist.txt', $tempfile);
+    print {$tempfile} "t/non-existent-file.txt\n";
+    $tempfile->close;
+
+    my $iter = File::Next::from_file( $tempfile->filename );
+    isa_ok( $iter, 'CODE' );
+
+    my @actual = slurp( $iter );
+    sets_match( \@actual, \@expected, 'FROM_FILESYSTEM_FILE' );
+
+    ok($warn_called, 'CORE::warn() should be called if a warning occurs and no warning_handler is set');
 }


### PR DESCRIPTION
Without this, we have the potential that $warn is undef, which will
cause a failure when a warning occurs.

Addresses https://github.com/petdance/ack2/issues/602