### PR TITLE
t/from_file.t error when run tainted on Windows cmd

### DIFF
--- a/t/from_file.t
+++ b/t/from_file.t
@@ -76,7 +76,7 @@ FROM_OK_FILE_BUT_MISSING: {
     my $warn_called;
     local $SIG{__WARN__} = sub { $warn_called = 1 };
 
-    my $tempfile = File::Temp->new;
+    my $tempfile = File::Temp->new(TEMPLATE => 'XXXXXXXXXX');
     File::Copy::copy('t/filelist.txt', $tempfile);
     print {$tempfile} "t/non-existent-file.txt\n";
     $tempfile->close;
@@ -94,7 +94,7 @@ FROM_OK_FILE_BUT_MISSING_WITH_HANDLER: {
     my $warn_called;
     local $SIG{__WARN__} = sub { $warn_called = 1 };
 
-    my $tempfile = File::Temp->new;
+    my $tempfile = File::Temp->new(TEMPLATE => 'XXXXXXXXXX');
     File::Copy::copy('t/filelist.txt', $tempfile);
     print {$tempfile} "t/non-existent-file.txt\n";
     $tempfile->close;
@@ -127,7 +127,7 @@ FROM_OK_FILE_BUT_MISSING_WITH_WARNING_HANDLER: {
     my $warning_handler_message;
     my $warning_handler = sub { $warning_handler_message = shift; };
 
-    my $tempfile = File::Temp->new;
+    my $tempfile = File::Temp->new(TEMPLATE => 'XXXXXXXXXX');
     File::Copy::copy('t/filelist.txt', $tempfile);
     print {$tempfile} "t/non-existent-file.txt\n";
     $tempfile->close;


### PR DESCRIPTION

http://www.cpantesters.org/cpan/report/bd6bc48b-6c4b-1014-bc90-c38f497dc0be

Perl will add backslash to default template in File::Temp when run in tainted mode on Command Line or PowerShell on Windows. This does not happen when script is run on cygwin.

Looks like adding explicit template for temp file solves the problem.

Example:
`perl -T -MFile::Temp -e "File::Temp->new"`

When run on command line and powershell:

`Error in tempfile() using template \XXXXXXXXXX: Could not create temp file \CtTSmMNBcg: Permission denied at -e line 1.
`

