### PR TITLE
Require File::Temp 0.22

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,6 +17,7 @@ my %parms = (
         'Test::More' => 0.88,
         'File::Copy' => 0,
         'File::Spec' => 0,
+        'File::Temp' => 0.22,
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'File-Next-*' },


### PR DESCRIPTION
Tests will fail if File::Temp is below this version
Addresses #29 