### PR TITLE
Skip undef $file in _candidate_files

### DIFF
--- a/Next.pm
+++ b/Next.pm
@@ -482,6 +482,7 @@ sub _candidate_files {
     my $follow_symlinks = $parms->{follow_symlinks};
 
     for my $file ( grep { !exists $skip_dirs{$_} } readdir $dh ) {
+        next unless $file;
         my $fullpath = File::Spec->catdir( $dirname, $file );
         if ( !$follow_symlinks ) {
             next if -l $fullpath;


### PR DESCRIPTION
readdir $fh can return undef in certain circumstances, like reading directories on SMB mounts.