### PR TITLE
fix: symlink not supported on Windows

### DIFF
--- a/t/follow.t
+++ b/t/follow.t
@@ -11,13 +11,13 @@ use File::Next;
 
 use File::Temp qw( tempdir );
 use File::Copy;
+use File::Spec;
 
-if ( ! eval { symlink('',''); 1 } ) {
-    plan skip_all => 'System does not support symlinks.';
+if ( ( $^O eq 'MSWin32' ) or ( ! eval { symlink('',''); 1 } ) ) {
+    plan skip_all => "OS $^O does not support symlinks.";
 }
 
 plan tests => 6;
-
 
 # Files to copy out of the swamp into the tempdir.
 my @samplefiles = qw(
@@ -30,37 +30,42 @@ my @samplefiles = qw(
 
 # Create a mini-swamp in the temp directory.
 my $tempdir = tempdir( CLEANUP => 1 );
-diag "t/follow.t is working with temp directory $tempdir";
-mkdir "$tempdir/dir" or die;
+my $test_location = File::Spec->catfile('t', 'follow.t');
+note "$test_location is working with temp directory $tempdir";
+
+my $sub_dir = 'dir';
+my $sub_temp_dir = File::Spec->catdir($tempdir, $sub_dir);
+mkdir $sub_temp_dir or die "Failed to create $sub_temp_dir: $!";
+
 for my $filename ( qw( a1 a2 ) ) {
-    my $tempfilename = "$tempdir/dir/$filename";
-    open( my $fh, '>', $tempfilename ) or die "$tempfilename: $!";
+    my $tempfilename = File::Spec->catfile($sub_temp_dir, $filename);
+    open( my $fh, '>', $tempfilename ) or die "Cannot create $tempfilename: $!";
     close $fh or die $!;
-    push( @samplefiles, "dir/$filename" );
+    push( @samplefiles, File::Spec->catfile($sub_dir, $filename ));
 }
 
 my @realfiles;
 for my $file ( @samplefiles ) {
-    my $tempfile = "$tempdir/$file";
-    copy( "t/swamp/$file", $tempfile );
+    my $tempfile = File::Spec->catfile($tempdir, $file);
+    copy( File::Spec->catfile('t', 'swamp', $file), $tempfile );
     push( @realfiles, $tempfile );
 }
 
 my %links = (
-    "$tempdir/linkfile" => "$tempdir/Makefile",
-    "$tempdir/linkdir"  => "$tempdir/dir",
+    File::Spec->catfile($tempdir, 'linkfile') => File::Spec->catfile($tempdir, 'Makefile'),
+    File::Spec->catfile($tempdir, 'linkdir')  => File::Spec->catdir($tempdir, 'dir'),
 );
 
 for my $link ( sort keys %links ) {
     my $file = $links{$link};
     unlink( $link );
-    symlink( $file, $link ) or die "Unable to create symlink $file: $!";
+    symlink( $file, $link ) or die "Unable to create symlink $link for $file: $!";
 }
 
 my @symlinkage = (
-    "$tempdir/linkfile",
-    "$tempdir/linkdir/a1",
-    "$tempdir/linkdir/a2",
+    File::Spec->catfile($tempdir, 'linkfile'),
+    File::Spec->catfile($tempdir, 'linkdir', 'a1'),
+    File::Spec->catfile($tempdir, 'linkdir', 'a2'),
 );
 
 DEFAULT: {
@@ -83,12 +88,14 @@ NO_FOLLOW: {
     sets_match( \@actual, \@expected, 'NO_FOLLOW' );
 }
 
+my $linkdir_regex = qr/linkdir/;
+
 NO_FOLLOW_STARTING_WITH_A_SYMLINK: {
-    my $iter = File::Next::files( { follow_symlinks => 0 }, "$tempdir/linkdir" );
+    my $iter = File::Next::files( { follow_symlinks => 0 }, File::Spec->catdir($tempdir, 'linkdir' ));
     isa_ok( $iter, 'CODE' );
 
     my @actual = slurp( $iter );
-    my @expected = grep { /linkdir/ } @symlinkage;
+    my @expected = grep { $linkdir_regex } @symlinkage;
 
     sets_match( \@actual, \@expected, 'NO_FOLLOW_STARTING_WITH_A_SYMLINK' );
 }


### PR DESCRIPTION
This will fix this [error](http://www.cpantesters.org/cpan/report/4a3be0a7-6e6d-1014-bf00-05e6efaa1848), that is the same I'm getting on MS Windows 11.

The current `eval` won't get the error from using `symlink`.

For some reason, `eval` will only set `$!` and not `$@` when `symlink(`) is used, so both would need to be tested after the `eval` block when running on:

```
perl -v

This is perl 5, version 38, subversion 0 (v5.38.0) built for MSWin32-x64-multi-thread
```

Also added `File::Spec` in order to make the paths more portable between OSes.

Full details:

```
perl -V
Summary of my perl5 (revision 5 version 38 subversion 0) configuration:

  Platform:
    osname=MSWin32
    osvers=10.0.17763.4499
    archname=MSWin32-x64-multi-thread
    uname='Win32 strawberry-perl 5.38.0.1 # 12:34:49 Thu July 06 2023 x64'
    config_args='undef'
    hint=recommended
    useposix=true
    d_sigaction=undef
    useithreads=define
    usemultiplicity=define
    use64bitint=define
    use64bitall=undef
    uselongdouble=undef
    usemymalloc=n
    default_inc_excludes_dot=define
  Compiler:
    cc='gcc'
    ccflags =' -DWIN32 -DWIN64 -DPERL_TEXTMODE_SCRIPTS -DMULTIPLICITY -DPERL_IMPLICIT_SYS -DUSE_PERLIO -D__USE_MINGW_ANSI_STDIO -fwrapv -fno-strict-aliasing -mms-bitfields'
    optimize='-Os'
    cppflags='-DWIN32'
    ccversion=''
    gccversion='13.1.0'
    gccosandvers=''
    intsize=4
    longsize=4
    ptrsize=8
    doublesize=8
    byteorder=12345678
    doublekind=3
    d_longlong=define
    longlongsize=8
    d_longdbl=define
    longdblsize=16
    longdblkind=3
    ivtype='long long'
    ivsize=8
    nvtype='double'
    nvsize=8
    Off_t='long long'
    lseeksize=8
    alignbytes=8
    prototype=define
  Linker and Libraries:
    ld='g++'
    ldflags ='-s -L"C:\STRAWB~1\perl\lib\CORE" -L"C:\STRAWB~1\c\lib" -L"C:\STRAWB~1\c\x86_64-w64-mingw32\lib" -L"C:\STRAWB~1\c\lib\gcc\x86_64-w64-mingw32\13.1.0"'
    libpth=C:\STRAWB~1\c\lib C:\STRAWB~1\c\x86_64-w64-mingw32\lib C:\STRAWB~1\c\lib\gcc\x86_64-w64-mingw32\13.1.0 C:\STRAWB~1\c\x86_64-w64-mingw32\lib C:\STRAWB~1\c\lib\gcc\x86_64-w64-mingw32\13.1.0
    libs= -lmoldname -lkernel32 -luser32 -lgdi32 -lwinspool -lcomdlg32 -ladvapi32 -lshell32 -lole32 -loleaut32 -lnetapi32 -luuid -lws2_32 -lmpr -lwinmm -lversion -lodbc32 -lodbccp32 -lcomctl32
    perllibs= -lmoldname -lkernel32 -luser32 -lgdi32 -lwinspool -lcomdlg32 -ladvapi32 -lshell32 -lole32 -loleaut32 -lnetapi32 -luuid -lws2_32 -lmpr -lwinmm -lversion -lodbc32 -lodbccp32 -lcomctl32
    libc=
    so=dll
    useshrplib=true
    libperl=libperl538.a
    gnulibc_version=''
  Dynamic Linking:
    dlsrc=dl_win32.xs
    dlext=xs.dll
    d_dlsymun=undef
    ccdlflags=' '
    cccdlflags=' '
    lddlflags='-shared -s -L"C:\STRAWB~1\perl\lib\CORE" -L"C:\STRAWB~1\c\lib" -L"C:\STRAWB~1\c\x86_64-w64-mingw32\lib" -L"C:\STRAWB~1\c\lib\gcc\x86_64-w64-mingw32\13.1.0"'


Characteristics of this binary (from libperl):
  Compile-time options:
    HAS_LONG_DOUBLE
    HAS_TIMES
    HAVE_INTERP_INTERN
    MULTIPLICITY
    PERLIO_LAYERS
    PERL_COPY_ON_WRITE
    PERL_DONT_CREATE_GVSV
    PERL_HASH_FUNC_SIPHASH13
    PERL_HASH_USE_SBOX32
    PERL_IMPLICIT_SYS
    PERL_MALLOC_WRAP
    PERL_OP_PARENT
    PERL_PRESERVE_IVUV
    PERL_USE_SAFE_PUTENV
    USE_64_BIT_INT
    USE_ITHREADS
    USE_LARGE_FILES
    USE_LOCALE
    USE_LOCALE_COLLATE
    USE_LOCALE_CTYPE
    USE_LOCALE_NUMERIC
    USE_LOCALE_TIME
    USE_PERLIO
    USE_PERL_ATOF
  Built under MSWin32
  Compiled at Jul  6 2023 22:36:11
  @INC:
    C:/Strawberry/perl/site/lib/MSWin32-x64-multi-thread
    C:/Strawberry/perl/site/lib
    C:/Strawberry/perl/vendor/lib
    C:/Strawberry/perl/lib
```